### PR TITLE
Dice roller: docked bottom tray with scrollable sheet above + last-10 roll history

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -499,19 +499,20 @@ Racial bonuses applied on top of base scores.
 
 ## Dice Roller (src/components/dice/DiceRollerModal.tsx)
 
-Floating action button (🎲) fixed bottom-right on the character sheet. Opens a modal with:
+Floating action button (🎲) fixed bottom-right on the character sheet. Opens a **docked bottom tray** (NOT a blocking modal — no backdrop) so the sheet above stays scrollable and tappable: look at your attack's modifiers and dice count, pick dice, and roll, all on one screen.
 
-- **8 dice:** d20, d12, d10, d% (percentile), d8, d6, d4, d2 — in a 2×4 grid
-- **Quantity selector:** +/− buttons per die type, 0–10
-- **Roll:** Counts reset to 0 immediately; dice sound plays; "Rolling…" shown for ~2.2 s while sound plays; results appear after sound finishes
-- **Results:** Individual roll chips, color-coded per die type; large total at bottom
-- **Clear:** Resets results and counts
+- **8 dice:** d20, d12, d10, d% (percentile), d8, d6, d4, d2 — one compact row on `sm:`+ (`grid-cols-8`), 2×4 on phones (`grid-cols-4`)
+- **Quantity selector:** tap a die chip to add one (count badge on the chip, max 10); thin − bar below each chip removes one
+- **Roll:** Counts reset to 0 immediately; dice sound plays; "Dice are tumbling…" shown for ~2.2 s while sound plays; results appear after sound finishes
+- **Results:** Inline row next to the Roll button — roll chips color-coded per die type, horizontally scrollable, total at right
+- **History:** 🕘 History toggle in the header shows the last 10 rolls (newest first): HH:MM time, per-die-group `N×dX` badge + individual rolls, total. In-memory only (persists while the sheet stays open — the tray component stays mounted when closed since `CharacterSheet` always renders it; not persisted to DB)
+- **Clear:** Resets results and counts (header button, only shown when there's something to clear)
 
 ### Key implementation notes
 - `colorMap` lookup object holds all Tailwind class strings statically (Tailwind v4 requirement — no template literals)
-- Results are computed eagerly (before counts reset) then revealed via `setTimeout(…, 2200)` to sync with sound
-- Modal triggered from `CharacterSheet.tsx` local state (`showDiceRoller`)
-- `z-40` for FAB, `z-50` for modal overlay (consistent with other modals)
+- Results are computed eagerly (before counts reset) then revealed via `setTimeout(…, 2200)` to sync with sound; the history entry is appended in the same timeout
+- Tray triggered from `CharacterSheet.tsx` local state (`showDiceRoller`); FAB is hidden while the tray is open; a `h-72` spacer div is appended to the sheet so the last content can scroll above the tray
+- Tray container: `fixed bottom-0 left-0 right-0 z-40` with `pointer-events-none` on the outer wrapper and `pointer-events-auto` on the panel (`max-w-2xl mx-auto`) — page content beside/above the panel stays clickable; real modals (`z-50`) cover the tray
 
 ### RULE: Always play dice sound when rolling
 **Whenever any dice are rolled anywhere in the app, `playDiceRollSound()` from `src/utils/diceSound.ts` MUST be called.**

--- a/src/components/dice/DiceRollerModal.tsx
+++ b/src/components/dice/DiceRollerModal.tsx
@@ -45,14 +45,30 @@ interface RollGroup {
   color: DieColor;
 }
 
+interface HistoryEntry {
+  id: number;
+  time: string;      // HH:MM display time
+  groups: RollGroup[];
+  total: number;
+}
+
+const EMPTY_COUNTS: Counts = { d20: 0, d12: 0, d10: 0, 'd%': 0, d8: 0, d6: 0, d4: 0, d2: 0 };
+
+const HISTORY_LIMIT = 10;
+
 // ── Main component ─────────────────────────────────────────────────────────────────────────────
+//
+// Docked bottom tray (not a blocking modal): no backdrop, so the character sheet
+// above stays scrollable and tappable — pick your attack, read your modifiers and
+// dice count, and roll without leaving the page. The component stays mounted while
+// the sheet is open, so counts/results/history survive closing and reopening the tray.
 
 export function DiceRollerModal({ isOpen, onClose }: Props) {
-  const [counts, setCounts] = useState<Counts>({
-    d20: 0, d12: 0, d10: 0, 'd%': 0, d8: 0, d6: 0, d4: 0, d2: 0,
-  });
+  const [counts, setCounts] = useState<Counts>(EMPTY_COUNTS);
   const [results, setResults] = useState<RollGroup[] | null>(null);
   const [rolling, setRolling] = useState(false);
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [showHistory, setShowHistory] = useState(false);
 
   if (!isOpen) return null;
 
@@ -84,168 +100,211 @@ export function DiceRollerModal({ isOpen, onClose }: Props) {
       }
       newResults.push({ label: die.label, sides: die.sides, rolls, color: die.color });
     }
+    const newTotal = newResults.reduce((sum, g) => sum + g.rolls.reduce((a, b) => a + b, 0), 0);
 
     // Play sound, reset counts, enter "rolling" state
     playDiceRollSound(totalDice);
-    setCounts({ d20: 0, d12: 0, d10: 0, 'd%': 0, d8: 0, d6: 0, d4: 0, d2: 0 });
+    setCounts(EMPTY_COUNTS);
     setRolling(true);
     setResults(null);
 
-    // Reveal results after sound finishes (~2.2 s)
+    // Reveal results after sound finishes (~2.2 s), then log to history
     setTimeout(() => {
       setResults(newResults);
       setRolling(false);
+      setHistory((prev) =>
+        [
+          {
+            id: Date.now(),
+            time: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+            groups: newResults,
+            total: newTotal,
+          },
+          ...prev,
+        ].slice(0, HISTORY_LIMIT),
+      );
     }, 2200);
   };
 
   const handleClear = () => {
-    setCounts({ d20: 0, d12: 0, d10: 0, 'd%': 0, d8: 0, d6: 0, d4: 0, d2: 0 });
+    setCounts(EMPTY_COUNTS);
     setResults(null);
   };
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/60 px-3 pb-3 sm:pb-0"
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-    >
-      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-sm overflow-hidden">
+    <div className="fixed bottom-0 left-0 right-0 z-40 pointer-events-none">
+      <div className="max-w-2xl mx-auto pointer-events-auto bg-white rounded-t-2xl border border-b-0 border-stone-300 shadow-[0_-6px_24px_rgba(0,0,0,0.28)]">
 
-        {/* ── Header ── */}
-        <div className="bg-amber-950 px-5 py-4 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <span className="text-2xl">🎲</span>
-            <h2 className="text-white font-bold text-lg">Dice Roller</h2>
+        {/* ── Header strip ── */}
+        <div className="bg-amber-950 rounded-t-2xl px-4 py-2 flex items-center gap-2">
+          <span className="text-lg">🎲</span>
+          <h2 className="text-white font-bold text-sm">Dice Roller</h2>
+
+          <div className="ml-auto flex items-center gap-1.5">
+            <button
+              onClick={() => setShowHistory((v) => !v)}
+              className={[
+                'text-xs font-semibold rounded-lg px-2.5 py-1.5 transition-colors',
+                showHistory
+                  ? 'bg-amber-700 text-white'
+                  : 'text-amber-300 hover:text-white hover:bg-amber-900',
+              ].join(' ')}
+              aria-label="Toggle roll history"
+            >
+              🕘 History{history.length > 0 ? ` (${history.length})` : ''}
+            </button>
+            {(hasAnyDice || results !== null) && (
+              <button
+                onClick={handleClear}
+                className="text-xs font-semibold text-amber-300 hover:text-white hover:bg-amber-900 rounded-lg px-2.5 py-1.5 transition-colors"
+              >
+                Clear
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="text-amber-300 hover:text-white transition-colors text-xl leading-none w-8 h-8 flex items-center justify-center"
+              aria-label="Close dice roller"
+            >
+              ×
+            </button>
           </div>
-          <button
-            onClick={onClose}
-            className="text-amber-300 hover:text-white transition-colors text-2xl leading-none w-8 h-8 flex items-center justify-center"
-            aria-label="Close dice roller"
-          >
-            ×
-          </button>
         </div>
 
-        <div className="px-4 pt-4 pb-3 space-y-3">
+        {/* ── Roll history (last 10) ── */}
+        {showHistory && (
+          <div className="border-b border-stone-200 max-h-40 overflow-y-auto">
+            {history.length === 0 ? (
+              <p className="px-4 py-2.5 text-xs text-stone-400 italic">No rolls yet this session.</p>
+            ) : (
+              <div className="divide-y divide-stone-100">
+                {history.map((h) => (
+                  <div key={h.id} className="px-4 py-1.5 flex items-center gap-2 text-xs">
+                    <span className="text-stone-400 tabular-nums flex-shrink-0 w-12">{h.time}</span>
+                    <div className="flex-1 min-w-0 flex items-center gap-1.5 overflow-x-auto whitespace-nowrap">
+                      {h.groups.map((g) => {
+                        const c = colorMap[g.color];
+                        return (
+                          <span key={g.label} className="inline-flex items-center gap-1 flex-shrink-0">
+                            <span className={`${c.badge} font-bold rounded px-1 py-0.5 text-[10px]`}>
+                              {g.rolls.length}×{g.label}
+                            </span>
+                            <span className="text-stone-600">{g.rolls.join(', ')}</span>
+                          </span>
+                        );
+                      })}
+                    </div>
+                    <span className="font-black text-amber-700 text-sm flex-shrink-0 tabular-nums">{h.total}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
 
-          {/* ── Die selectors — 2 columns × 4 rows ── */}
-          <div className="grid grid-cols-2 gap-2">
+        <div className="px-3 pt-2.5 pb-3 space-y-2.5">
+
+          {/* ── Die selectors — tap a die to add one, thin − bar to remove ── */}
+          <div className="grid grid-cols-4 sm:grid-cols-8 gap-1.5">
             {DICE.map((die) => {
               const c = colorMap[die.color];
+              const count = counts[die.label];
               return (
-                <div key={die.label} className="flex items-center gap-2">
-                  {/* Die label badge */}
-                  <span className={`${c.badge} text-xs font-bold rounded-lg px-2 py-1.5 min-w-[3rem] text-center flex-shrink-0`}>
+                <div key={die.label} className="flex flex-col gap-1">
+                  <button
+                    onClick={() => adjust(die.label, +1)}
+                    disabled={count >= 10}
+                    className={[
+                      'relative h-11 rounded-lg border font-bold text-sm transition-colors',
+                      c.bg, c.text, c.border,
+                      count >= 10 ? 'opacity-50 cursor-not-allowed' : 'hover:brightness-95 active:brightness-90',
+                    ].join(' ')}
+                    aria-label={`Add ${die.label}`}
+                  >
                     {die.label}
-                  </span>
-
-                  {/* minus button */}
+                    {count > 0 && (
+                      <span
+                        className={`${c.badge} absolute -top-1.5 -right-1.5 text-[11px] font-bold rounded-full min-w-[1.25rem] h-5 px-1 flex items-center justify-center`}
+                      >
+                        {count}
+                      </span>
+                    )}
+                  </button>
                   <button
                     onClick={() => adjust(die.label, -1)}
-                    disabled={counts[die.label] === 0}
+                    disabled={count === 0}
                     className={[
-                      'w-9 h-9 rounded-lg text-lg font-bold transition-colors flex items-center justify-center flex-shrink-0',
-                      counts[die.label] === 0
-                        ? 'bg-stone-100 text-stone-300 cursor-not-allowed'
-                        : 'bg-stone-200 hover:bg-stone-300 active:bg-stone-400 text-stone-700',
+                      'h-6 rounded text-sm font-bold leading-none transition-colors',
+                      count === 0
+                        ? 'bg-stone-50 text-stone-200 cursor-not-allowed'
+                        : 'bg-stone-200 hover:bg-stone-300 active:bg-stone-400 text-stone-600',
                     ].join(' ')}
                     aria-label={`Remove ${die.label}`}
                   >
                     −
-                  </button>
-
-                  {/* Count */}
-                  <span className="w-6 text-center font-bold text-xl text-stone-800 flex-shrink-0">
-                    {counts[die.label]}
-                  </span>
-
-                  {/* plus button */}
-                  <button
-                    onClick={() => adjust(die.label, +1)}
-                    disabled={counts[die.label] >= 10}
-                    className={[
-                      'w-9 h-9 rounded-lg text-lg font-bold transition-colors flex items-center justify-center flex-shrink-0',
-                      counts[die.label] >= 10
-                        ? 'bg-stone-100 text-stone-300 cursor-not-allowed'
-                        : 'bg-stone-200 hover:bg-stone-300 active:bg-stone-400 text-stone-700',
-                    ].join(' ')}
-                    aria-label={`Add ${die.label}`}
-                  >
-                    +
                   </button>
                 </div>
               );
             })}
           </div>
 
-          {/* ── Roll button ── */}
-          <button
-            onClick={handleRoll}
-            disabled={!hasAnyDice || rolling}
-            className={[
-              'w-full h-12 rounded-xl text-lg font-bold transition-colors',
-              !hasAnyDice || rolling
-                ? 'bg-stone-200 text-stone-400 cursor-not-allowed'
-                : 'bg-amber-700 hover:bg-amber-600 active:bg-amber-800 text-white',
-            ].join(' ')}
-          >
-            {rolling ? 'Rolling…' : '🎲 Roll'}
-          </button>
+          {/* ── Roll button + inline results ── */}
+          <div className="flex items-center gap-2.5">
+            <button
+              onClick={handleRoll}
+              disabled={!hasAnyDice || rolling}
+              className={[
+                'h-11 px-5 rounded-xl text-base font-bold transition-colors flex-shrink-0',
+                !hasAnyDice || rolling
+                  ? 'bg-stone-200 text-stone-400 cursor-not-allowed'
+                  : 'bg-amber-700 hover:bg-amber-600 active:bg-amber-800 text-white',
+              ].join(' ')}
+            >
+              {rolling ? 'Rolling…' : '🎲 Roll'}
+            </button>
 
-          {/* ── Results ── */}
-          {results !== null && (
-            <div className="border border-stone-200 rounded-xl overflow-hidden">
-
-              {/* Individual result groups */}
-              <div className="px-4 pt-3 pb-2 space-y-2">
-                {results.map((group) => {
+            <div className="flex-1 min-w-0 flex items-center gap-1.5 overflow-x-auto whitespace-nowrap">
+              {rolling ? (
+                <span className="text-sm text-stone-400 italic">Dice are tumbling…</span>
+              ) : results !== null ? (
+                results.map((group) => {
                   const c = colorMap[group.color];
                   return (
-                    <div key={group.label} className="flex items-center gap-2 flex-wrap">
-                      <span className={`${c.badge} text-xs font-bold rounded px-1.5 py-0.5 flex-shrink-0`}>
+                    <span key={group.label} className="inline-flex items-center gap-1 flex-shrink-0">
+                      <span className={`${c.badge} text-[10px] font-bold rounded px-1 py-0.5`}>
                         {group.label}
                       </span>
-                      <div className="flex flex-wrap gap-1">
-                        {group.rolls.map((r, i) => (
-                          <span
-                            key={i}
-                            className={[
-                              'min-w-[2rem] h-8 rounded-full border flex items-center justify-center text-sm font-bold',
-                              c.bg, c.text, c.border,
-                            ].join(' ')}
-                          >
-                            {r}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
+                      {group.rolls.map((r, i) => (
+                        <span
+                          key={i}
+                          className={[
+                            'min-w-[1.75rem] h-7 px-1 rounded-full border flex items-center justify-center text-xs font-bold',
+                            c.bg, c.text, c.border,
+                          ].join(' ')}
+                        >
+                          {r}
+                        </span>
+                      ))}
+                    </span>
                   );
-                })}
-              </div>
-
-              {/* Total */}
-              <div className="bg-stone-50 border-t border-stone-200 px-4 py-3 flex items-center justify-between">
-                <span className="text-sm font-semibold text-stone-500 uppercase tracking-wide">Total</span>
-                <span className="text-4xl font-black text-amber-700">{total}</span>
-              </div>
-
+                })
+              ) : (
+                <span className="text-sm text-stone-400">
+                  {hasAnyDice ? 'Ready — hit Roll' : 'Tap dice to add them'}
+                </span>
+              )}
             </div>
-          )}
 
-          {/* ── Clear ── */}
-          {(hasAnyDice || results !== null) && (
-            <div className="flex justify-end">
-              <button
-                onClick={handleClear}
-                className="text-xs text-stone-400 hover:text-stone-600 transition-colors underline underline-offset-2"
-              >
-                Clear
-              </button>
-            </div>
-          )}
+            {results !== null && !rolling && (
+              <div className="flex-shrink-0 flex items-baseline gap-1.5 pl-1">
+                <span className="text-[10px] font-semibold text-stone-400 uppercase tracking-wide">Total</span>
+                <span className="text-3xl font-black text-amber-700 tabular-nums">{total}</span>
+              </div>
+            )}
+          </div>
 
         </div>
       </div>
     </div>
   );
 }
-

--- a/src/components/sheet/CharacterSheet.tsx
+++ b/src/components/sheet/CharacterSheet.tsx
@@ -303,17 +303,21 @@ export function CharacterSheet({ character, readOnly = false }: Props) {
         </div>
       )}
 
-      {/* ── Floating Dice Roller FAB ── */}
+      {/* ── Floating Dice Roller FAB + docked bottom tray ── */}
       {!readOnly && (
         <>
-          <button
-            onClick={() => setShowDiceRoller(true)}
-            className="fixed bottom-6 right-6 z-40 w-16 h-16 rounded-full bg-amber-700 hover:bg-amber-600 active:bg-amber-800 text-white shadow-lg flex items-center justify-center text-2xl transition-colors"
-            title="Dice Roller"
-            aria-label="Open dice roller"
-          >
-            🎲
-          </button>
+          {!showDiceRoller && (
+            <button
+              onClick={() => setShowDiceRoller(true)}
+              className="fixed bottom-6 right-6 z-40 w-16 h-16 rounded-full bg-amber-700 hover:bg-amber-600 active:bg-amber-800 text-white shadow-lg flex items-center justify-center text-2xl transition-colors"
+              title="Dice Roller"
+              aria-label="Open dice roller"
+            >
+              🎲
+            </button>
+          )}
+          {/* Spacer so the bottom of the sheet can scroll up above the docked tray */}
+          {showDiceRoller && <div className="h-72" aria-hidden="true" />}
           <DiceRollerModal isOpen={showDiceRoller} onClose={() => setShowDiceRoller(false)} />
         </>
       )}

--- a/src/pages/InstructionsPage.tsx
+++ b/src/pages/InstructionsPage.tsx
@@ -148,12 +148,15 @@ const SECTIONS: Section[] = [
 
         <h3 className={h3}>The floating dice roller (🎲)</h3>
         <p>
-          A floating button bottom-right of any character sheet. Tap to open the dice modal.
+          A floating button bottom-right of any character sheet. Tap to open the dice tray, which docks
+          across the bottom of the screen — the sheet above stays scrollable, so you can read your attack's
+          modifiers and dice count while you build the roll.
         </p>
         <ul className={ul}>
-          <li>Build a roll with d2 / d4 / d6 / d8 / d10 / d% / d12 / d20 — up to 10 of each, counts shown.</li>
+          <li>Build a roll with d2 / d4 / d6 / d8 / d10 / d% / d12 / d20 — tap a die to add one (up to 10 of each, count badge on the chip), tap the <span className={k}>−</span> bar below it to remove one.</li>
           <li>Tap <span className={k}>Roll</span> — dice sound plays (Web Audio synthesized, no audio files), results appear after the ~2-second sound finishes.</li>
-          <li>Each result chip is color-coded per die. Total at bottom. Tap <span className={k}>Clear</span> to reset.</li>
+          <li>Result chips are color-coded per die and appear right next to the Roll button, with the total at the right. Tap <span className={k}>Clear</span> to reset.</li>
+          <li>Tap <span className={k}>🕘 History</span> in the tray header to see your last 10 rolls (time, individual dice, and total). History lasts while the sheet is open — it isn't saved.</li>
         </ul>
 
         <h3 className={h3}>Implicit rolls</h3>


### PR DESCRIPTION
Redesigns the dice roller so you can build a roll while reading your character sheet — e.g. look at an attack power's modifiers and dice count, add the dice, hit Roll, and see the results, all on one screen.

## Docked bottom tray (was: blocking modal)

- The 🎲 FAB now opens a compact tray **docked across the bottom of the screen** with **no backdrop** — the sheet above stays fully scrollable and tappable while the tray is open.
- Dice selection is one row of 8 chips on tablet/desktop (2×4 on phones): **tap a die to add one** (count badge appears on the chip, max 10 each), thin **−** bar below each chip removes one.
- Roll button and results share a single inline row: color-coded roll chips (horizontally scrollable when there are many) with the big total on the right. Same sound/timing behavior as before — results reveal after the ~2.2 s dice sound.
- The FAB hides while the tray is open; a spacer div keeps the very bottom of the sheet reachable above the tray. The tray sits at `z-40` with a `pointer-events-none` outer wrapper so page content beside it stays clickable, and real modals (`z-50`) still cover it.

## Roll history (last 10)

- New **🕘 History** toggle in the tray header lists the last 10 rolls, newest first: HH:MM time, per-die-group breakdown (`2×d6` badge + the individual rolls), and the total.
- History is kept in memory while the sheet is open — the tray component stays mounted when closed, so closing/reopening the tray doesn't lose it. Not persisted to the DB.

## Docs

- CLAUDE.md dice roller section rewritten to describe the tray + history.
- User manual (`InstructionsPage`) dice roller section updated to match.

`npm run build` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rR6fCX8zUdCpmrG4F46HA

---
_Generated by [Claude Code](https://claude.ai/code/session_013rR6fCX8zUdCpmrG4F46HA)_